### PR TITLE
Feature/preprocess testing data

### DIFF
--- a/text-sentiment-analysis-1/conf/base/catalog.yml
+++ b/text-sentiment-analysis-1/conf/base/catalog.yml
@@ -31,11 +31,6 @@ stopwords_custom:
   filepath: data/02_intermediate/tools/stopwords_custom.txt
   layer: intermediate
 
-converted_labelled_data:
-  type: pandas.ParquetDataSet
-  filepath: data/02_intermediate/converted_labelled_data.pq
-  layer: intermediate
-
 preprocessed_labelled_data:
   type: pandas.ParquetDataSet
   filepath: data/03_primary/preprocessed_labelled_data.pq

--- a/text-sentiment-analysis-1/conf/base/catalog.yml
+++ b/text-sentiment-analysis-1/conf/base/catalog.yml
@@ -40,3 +40,8 @@ preprocessed_labelled_data:
   type: pandas.ParquetDataSet
   filepath: data/03_primary/preprocessed_labelled_data.pq
   layer: primary
+
+preprocessed_testing_data:
+  type: pandas.ParquetDataSet
+  filepath: data/03_primary/preprocessed_testing_data.pq
+  layer: primary

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -137,29 +137,28 @@ def extract_and_convert_testing_data(xml_content: str) -> pd.DataFrame:
     dataframe = _convert_testing_data_tree_to_dataframe(tree)
     return dataframe
 
-def preprocess_labelled_data(
-        labelled_data: pd.DataFrame,
+def preprocess_text_column(
+        dataframe: pd.DataFrame,
         stopwords_custom: str,
     ) -> pd.DataFrame:
-    """Preprocess text data of reviews in labelled_data dataframe 
+    """Preprocess 'text' column in dataframe 
     
     Args:
-        labelled_data: customer reviews data 
+        dataframe: customer reviews data
         accompanied with sentiment & aspect labels
 
     Returns:
-        same data structure of labelled_data 
-        but with review text in the normalized form.
+        dataframe with preprocessed 'text' column
         preprocessing includes:
         - regular expression
         - stopwords removal
         - custom stopwords removal
         TODO: add lemmatization
     """
-    labelled_data["text"] = _normalize_text_column(labelled_data["text"])
-    labelled_data["text"] = _remove_stopwords_in_text_column(labelled_data["text"])
-    labelled_data["text"] = _remove_custom_stopwords_in_text_column(
-        labelled_data["text"], 
+    dataframe["text"] = _normalize_text_column(dataframe["text"])
+    dataframe["text"] = _remove_stopwords_in_text_column(dataframe["text"])
+    dataframe["text"] = _remove_custom_stopwords_in_text_column(
+        dataframe["text"], 
         stopwords_custom
     )
-    return labelled_data
+    return dataframe

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -17,10 +17,23 @@ def _extract_xml_tree_from_text(content: str) -> ET.ElementTree:
     parser = etree.XMLParser(recover=True) # recover=T -> skip broken form
     return ET.ElementTree(ET.fromstring(content, parser=parser))
 
+def _convert_testing_data_tree_to_dataframe(tree: ET.ElementTree) -> pd.DataFrame:
+    root = tree.getroot()
+    columns = ["review_id", "text"]
+    rows = []
+
+    for node in root:
+        review_id = node.find("index").text
+        text = node.find("review").text
+        row = {"review_id": review_id, "text": text}
+    
+    dataframe = pd.DataFrame(rows, columns = columns)
+    return dataframe
+
 def _convert_labelled_data_tree_to_dataframe(tree: ET.ElementTree) -> pd.DataFrame:
     root = tree.getroot()
     columns = [
-        "rid", "text", 
+        "review_id", "text", 
         "food_0", "price_0", "ambience_0", "service_0", 
         "food_1", "price_1", "ambience_1", "service_1"
     ] 
@@ -31,7 +44,7 @@ def _convert_labelled_data_tree_to_dataframe(tree: ET.ElementTree) -> pd.DataFra
         review_text = node.find("text").text if node is not None else None
         reviewers = node.findall("aspects")      
         row_payload = {
-            "rid": review_id, "text": review_text,
+            "review_id": review_id, "text": review_text,
             "food_0": "unknown", "price_0": "unknown", "ambience_0": "unknown", "service_0": "unknown",
             "food_1": "unknown", "price_1": "unknown", "ambience_1": "unknown", "service_1": "unknown"
         }
@@ -102,11 +115,26 @@ def extract_and_convert_labelled_data(xml_content: str) -> pd.DataFrame:
         xml_content: full content of xml file represented in string
 
     Returns:
-        Content of xml file represented in pandas dataframe
+        Content of xml file of labelled data represented in pandas dataframe
         with renamed column
     """
     tree = _extract_xml_tree_from_text(xml_content)
     dataframe = _convert_labelled_data_tree_to_dataframe(tree)
+    return dataframe
+
+def extract_and_convert_testing_data(xml_content: str) -> pd.DataFrame:
+    """ Extract content of XML file of testing data 
+        and convert to pandas Dataframe
+    
+    Args:
+        xml_content: full content of xml file represented in string
+
+    Returns:
+        Content of xml file of testing data represented in pandas dataframe
+        with renamed column
+    """
+    tree = _extract_xml_tree_from_text(xml_content)
+    dataframe = _convert_testing_data_tree_to_dataframe(tree)
     return dataframe
 
 def preprocess_labelled_data(

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
@@ -41,7 +41,6 @@ def create_pipeline(**kwargs) -> Pipeline:
             "stopwords_custom",
         ],
         outputs=[
-            "converted_labelled_data", 
             "preprocessed_labelled_data", 
             "preprocessed_testing_data",
         ],

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
@@ -4,7 +4,7 @@ generated using Kedro 0.17.7
 """
 
 from kedro.pipeline import Pipeline, node, pipeline
-from .nodes import extract_and_convert_labelled_data, preprocess_labelled_data
+from .nodes import extract_and_convert_labelled_data, extract_and_convert_testing_data, preprocess_labelled_data
 
 def create_pipeline(**kwargs) -> Pipeline:
     return pipeline(
@@ -21,8 +21,28 @@ def create_pipeline(**kwargs) -> Pipeline:
                 outputs="preprocessed_labelled_data",
                 name="preprocess_labelled_data_node",
             ),
+            node(
+                func=extract_and_convert_testing_data,
+                inputs="testing_data",
+                outputs="converted_testing_data",
+                name="extract_and_convert_testing_data_node",
+            ),
+            node(
+                func=preprocess_labelled_data,
+                inputs=["converted_testing_data", "stopwords_custom"],
+                outputs="preprocessed_testing_data",
+                name="preprocess_testing_data_node",
+            ),
         ],
         namespace="data_preprocessing", 
-        inputs=["labelled_data", "stopwords_custom"],
-        outputs=["converted_labelled_data", "preprocessed_labelled_data"],
+        inputs=[
+            "labelled_data",
+            "testing_data",
+            "stopwords_custom",
+        ],
+        outputs=[
+            "converted_labelled_data", 
+            "preprocessed_labelled_data", 
+            "preprocessed_testing_data",
+        ],
     )

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
@@ -4,7 +4,7 @@ generated using Kedro 0.17.7
 """
 
 from kedro.pipeline import Pipeline, node, pipeline
-from .nodes import extract_and_convert_labelled_data, extract_and_convert_testing_data, preprocess_labelled_data
+from .nodes import extract_and_convert_labelled_data, extract_and_convert_testing_data, preprocess_text_column
 
 def create_pipeline(**kwargs) -> Pipeline:
     return pipeline(
@@ -16,7 +16,7 @@ def create_pipeline(**kwargs) -> Pipeline:
                 name="extract_and_convert_labelled_data_node",
             ),
             node(
-                func=preprocess_labelled_data,
+                func=preprocess_text_column,
                 inputs=["converted_labelled_data", "stopwords_custom"],
                 outputs="preprocessed_labelled_data",
                 name="preprocess_labelled_data_node",
@@ -28,7 +28,7 @@ def create_pipeline(**kwargs) -> Pipeline:
                 name="extract_and_convert_testing_data_node",
             ),
             node(
-                func=preprocess_labelled_data,
+                func=preprocess_text_column,
                 inputs=["converted_testing_data", "stopwords_custom"],
                 outputs="preprocessed_testing_data",
                 name="preprocess_testing_data_node",


### PR DESCRIPTION
Added new feature to preprocess testing data
- use pre-existing text pre-processing script
- refactor node's name: `preprocess_labelled_data` -> `preprocess_text_column` for reusability and more general name
- remove converted_labelled_data from the data catalog as it's not used