### PR TITLE
Feature/preprocess gold standard

### DIFF
--- a/text-sentiment-analysis-1/conf/base/catalog.yml
+++ b/text-sentiment-analysis-1/conf/base/catalog.yml
@@ -36,11 +36,6 @@ preprocessed_labelled_data:
   filepath: data/03_primary/preprocessed_labelled_data.pq
   layer: primary
 
-preprocessed_testing_data:
-  type: pandas.ParquetDataSet
-  filepath: data/03_primary/preprocessed_testing_data.pq
-  layer: primary
-
 testing_data_table:
   type: pandas.ParquetDataSet
   filepath: data/03_primary/testing_data_table.pq

--- a/text-sentiment-analysis-1/conf/base/catalog.yml
+++ b/text-sentiment-analysis-1/conf/base/catalog.yml
@@ -40,3 +40,8 @@ preprocessed_testing_data:
   type: pandas.ParquetDataSet
   filepath: data/03_primary/preprocessed_testing_data.pq
   layer: primary
+
+testing_data_table:
+  type: pandas.ParquetDataSet
+  filepath: data/03_primary/testing_data_table.pq
+  layer: primary

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -108,6 +108,9 @@ def _remove_custom_stopwords_in_text_column(
     data_series = data_series.apply(_sw_removal_helper)
     return data_series
 
+def _map_label(x: str, mapper: dict) -> str:
+    return mapper[x]
+
 def extract_and_convert_labelled_data(xml_content: str) -> pd.DataFrame:
     """ Extract content of XML file of labelled data 
         and convert to pandas Dataframe

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -146,6 +146,11 @@ def preprocess_text_column(
         stopwords_custom: str,
     ) -> pd.DataFrame:
     """Preprocess 'text' column in dataframe 
+        includes:
+        - regular expression
+        - stopwords removal
+        - custom stopwords removal
+        TODO: add lemmatization
     
     Args:
         dataframe: customer reviews data
@@ -153,11 +158,6 @@ def preprocess_text_column(
 
     Returns:
         dataframe with preprocessed 'text' column
-        preprocessing includes:
-        - regular expression
-        - stopwords removal
-        - custom stopwords removal
-        TODO: add lemmatization
     """
     dataframe["text"] = _normalize_text_column(dataframe["text"])
     dataframe["text"] = _remove_stopwords_in_text_column(dataframe["text"])
@@ -168,7 +168,17 @@ def preprocess_text_column(
     return dataframe
 
 def preprocess_gold_standard(dataframe: pd.DataFrame) -> pd.DataFrame:
-    """
+    """ Preprocess gold_standard (labels of testing_data)
+        includes: 
+        - column renaming 
+        - label name conversion (with label_mapper)
+
+    Args:
+        dataframe: dataframe of sentiment labels 
+                for all aspects (food, ambience, service, price)
+
+    Returns:
+        preprocessed dataframe
     """
     dataframe = dataframe.rename(columns={
         'ID':'review_id', 
@@ -199,6 +209,13 @@ def create_testing_data_table(
     """ Join testing_data and gold_standard (as labels of testing_data)
         based on review_id
 
+    Args:
+        reviews: dataframe (from testing_data) containing id and review texts
+        labels: dataframe containing sentiment labels for all 4 aspects
+            referencing to 'reviews' (testing_data)
+    
+    Return:
+        complete testing data table containing review text and it's label
     """
     labelled_testing_data = reviews.merge(
         labels, 

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -23,9 +23,10 @@ def _convert_testing_data_tree_to_dataframe(tree: ET.ElementTree) -> pd.DataFram
     rows = []
 
     for node in root:
-        review_id = node.find("index").text
+        review_id = int(node.find("index").text)
         text = node.find("review").text
         row = {"review_id": review_id, "text": text}
+        rows.append(row)
     
     dataframe = pd.DataFrame(rows, columns = columns)
     return dataframe
@@ -40,7 +41,7 @@ def _convert_labelled_data_tree_to_dataframe(tree: ET.ElementTree) -> pd.DataFra
     rows = []
 
     for node in root:
-        review_id = node.attrib.get("rid")
+        review_id = int(node.attrib.get("rid"))
         review_text = node.find("text").text if node is not None else None
         reviewers = node.findall("aspects")      
         row_payload = {

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -166,3 +166,28 @@ def preprocess_text_column(
         stopwords_custom
     )
     return dataframe
+
+def preprocess_gold_standard_labels(dataframe: pd.DataFrame) -> pd.DataFrame:
+    """
+    """
+    dataframe = dataframe.rename(columns={
+        'ID':'review_id', 
+        "FOOD": "food", 
+        "SERVICE":"service", 
+        "AMBIENCE":"ambience", 
+        "PRICE": "price"
+    })
+    label_mapper = {
+        "-": "unknown",
+        "NEGATIVE": "negative",
+        "POSITIVE": "positive",
+    }
+
+    def _map_label_helper(x:str) -> str:
+        return _map_label(x, label_mapper)
+
+    dataframe["food"] = dataframe["food"].apply(_map_label_helper)
+    dataframe["price"] = dataframe["price"].apply(_map_label_helper)
+    dataframe["service"] = dataframe["service"].apply(_map_label_helper)
+    dataframe["ambience"] = dataframe["ambience"].apply(_map_label_helper)
+    return dataframe

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -191,3 +191,19 @@ def preprocess_gold_standard_labels(dataframe: pd.DataFrame) -> pd.DataFrame:
     dataframe["service"] = dataframe["service"].apply(_map_label_helper)
     dataframe["ambience"] = dataframe["ambience"].apply(_map_label_helper)
     return dataframe
+
+def create_testing_data_table(
+        reviews: pd.DataFrame,
+        labels: pd.DataFrame,
+    ) -> pd.DataFrame:
+    """ Join testing_data and gold_standard (as labels of testing_data)
+        based on review_id
+
+    """
+    labelled_testing_data = reviews.merge(
+        labels, 
+        left_on="review_id", 
+        right_on="review_id",
+    )
+    testing_data_table = labelled_testing_data.dropna()
+    return testing_data_table

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -167,7 +167,7 @@ def preprocess_text_column(
     )
     return dataframe
 
-def preprocess_gold_standard_labels(dataframe: pd.DataFrame) -> pd.DataFrame:
+def preprocess_gold_standard(dataframe: pd.DataFrame) -> pd.DataFrame:
     """
     """
     dataframe = dataframe.rename(columns={

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
@@ -54,9 +54,7 @@ def create_pipeline(**kwargs) -> Pipeline:
             "gold_standard"
         ],
         outputs=[
-            "preprocessed_labelled_data", 
-            "preprocessed_testing_data",
-            "testing_data_labels",
+            "preprocessed_labelled_data",
             "testing_data_table",
         ],
     )

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
@@ -4,7 +4,7 @@ generated using Kedro 0.17.7
 """
 
 from kedro.pipeline import Pipeline, node, pipeline
-from .nodes import extract_and_convert_labelled_data, extract_and_convert_testing_data, preprocess_text_column, preprocess_gold_standard_labels, create_testing_data_table
+from .nodes import extract_and_convert_labelled_data, extract_and_convert_testing_data, preprocess_text_column, preprocess_gold_standard, create_testing_data_table
 
 def create_pipeline(**kwargs) -> Pipeline:
     return pipeline(
@@ -34,7 +34,7 @@ def create_pipeline(**kwargs) -> Pipeline:
                 name="preprocess_testing_data_node",
             ),
             node(
-                func=preprocess_gold_standard_labels,
+                func=preprocess_gold_standard,
                 inputs="gold_standard",
                 outputs="testing_data_labels",
                 name="preprocess_gold_standard_node",

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
@@ -4,7 +4,7 @@ generated using Kedro 0.17.7
 """
 
 from kedro.pipeline import Pipeline, node, pipeline
-from .nodes import extract_and_convert_labelled_data, extract_and_convert_testing_data, preprocess_text_column
+from .nodes import extract_and_convert_labelled_data, extract_and_convert_testing_data, preprocess_text_column, preprocess_gold_standard_labels, create_testing_data_table
 
 def create_pipeline(**kwargs) -> Pipeline:
     return pipeline(
@@ -33,15 +33,30 @@ def create_pipeline(**kwargs) -> Pipeline:
                 outputs="preprocessed_testing_data",
                 name="preprocess_testing_data_node",
             ),
+            node(
+                func=preprocess_gold_standard_labels,
+                inputs="gold_standard",
+                outputs="testing_data_labels",
+                name="preprocess_gold_standard_node",
+            ),
+            node(
+                func=create_testing_data_table,
+                inputs=["preprocessed_testing_data", "testing_data_labels"],
+                outputs="testing_data_table",
+                name="create_testing_data_table_node",
+            )
         ],
         namespace="data_preprocessing", 
         inputs=[
             "labelled_data",
             "testing_data",
             "stopwords_custom",
+            "gold_standard"
         ],
         outputs=[
             "preprocessed_labelled_data", 
             "preprocessed_testing_data",
+            "testing_data_labels",
+            "testing_data_table",
         ],
     )


### PR DESCRIPTION
Added gold_standard preprocessing into preprocessing node!

**Notes:**
- `gold_standard` is a data frame containing **only** labels referencing to `testing_data`
- only 200 rows available in gold_standard (~1,4% from all testing_data.xml)

**What was included**
- preprocess `gold_standard` to match labels & column names used in `preprocessed_labelled_data` and/or `preprocessed_testing_data`
- fix bug on `_convert_testing_data_tree_to_dataframe`, [line 29](https://github.com/adammln/kedro-lab/commit/047e91d46f971c7f8208c0ad983504f1df93371d)
- create join table of preprocessed testing_data & preprocessed gold_standard
