### PR TITLE
Feature/add label agreement measures

### DIFF
--- a/text-sentiment-analysis-1/conf/base/catalog.yml
+++ b/text-sentiment-analysis-1/conf/base/catalog.yml
@@ -63,9 +63,9 @@ agreed_aspect_table:
   filepath: data/03_primary/agreed_aspect_table.pq
   layer: primary
 
-agreed_aspect_table:
+agreed_polarity_table:
   type: pandas.ParquetDataSet
-  filepath: data/03_primary/agreed_aspect_table.pq
+  filepath: data/03_primary/agreed_polarity_table.pq
   layer: primary
 
 feature_tf_train:

--- a/text-sentiment-analysis-1/conf/base/catalog.yml
+++ b/text-sentiment-analysis-1/conf/base/catalog.yml
@@ -12,19 +12,16 @@ labelled_data:
   type: text.TextDataSet
   filepath: data/01_raw/labelled_data.xml
   layer: raw
-  # file_format: xml
 
 testing_data:
   type: text.TextDataSet
   filepath: data/01_raw/testing_data.xml
   layer: raw
-  # file_format: xml
 
 unlabelled_data:
   type: text.TextDataSet
   filepath: data/01_raw/unlabelled_data.xml
   layer: raw
-  # file_format: xml
 
 typed_unlabelled_data:
   type: pandas.ParquetDataSet
@@ -59,6 +56,16 @@ unlabelled_data_table:
 gold_standard_table:
   type: pandas.ParquetDataSet
   filepath: data/03_primary/gold_standard_table.pq
+  layer: primary
+
+agreed_aspect_table:
+  type: pandas.ParquetDataSet
+  filepath: data/03_primary/agreed_aspect_table.pq
+  layer: primary
+
+agreed_aspect_table:
+  type: pandas.ParquetDataSet
+  filepath: data/03_primary/agreed_aspect_table.pq
   layer: primary
 
 feature_tf_train:

--- a/text-sentiment-analysis-1/src/requirements.in
+++ b/text-sentiment-analysis-1/src/requirements.in
@@ -16,4 +16,5 @@ pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0
 pytest~=6.2
 scikit-learn~=1.0.2
+statsmodels~=0.13.2
 wheel>=0.35, <0.37

--- a/text-sentiment-analysis-1/src/requirements.txt
+++ b/text-sentiment-analysis-1/src/requirements.txt
@@ -225,9 +225,11 @@ notebook-shim==0.1.0
 numpy==1.22.2
     # via
     #   pandas
+    #   patsy
     #   pyarrow
     #   scikit-learn
     #   scipy
+    #   statsmodels
 packaging==21.3
     # via
     #   bleach
@@ -236,14 +238,19 @@ packaging==21.3
     #   jupyterlab-server
     #   pytest
     #   qtpy
+    #   statsmodels
 pandas==1.3.5
-    # via kedro
+    # via
+    #   kedro
+    #   statsmodels
 pandocfilters==1.5.0
     # via nbconvert
 parso==0.8.3
     # via jedi
 pathspec==0.9.0
     # via black
+patsy==0.5.2
+    # via statsmodels
 pep517==0.12.0
     # via pip-tools
 pexpect==4.8.0
@@ -341,7 +348,9 @@ rope==0.21.1
 scikit-learn==1.0.2
     # via -r /home/adamln/Dev/lab/kedro-lab/text-sentiment-analysis-1/src/requirements.in
 scipy==1.8.0
-    # via scikit-learn
+    # via
+    #   scikit-learn
+    #   statsmodels
 send2trash==1.8.0
     # via
     #   jupyter-server
@@ -350,11 +359,14 @@ six==1.16.0
     # via
     #   bleach
     #   cookiecutter
+    #   patsy
     #   python-dateutil
 smmap==5.0.0
     # via gitdb
 sniffio==1.2.0
     # via anyio
+statsmodels==0.13.2
+    # via -r /home/adamln/Dev/lab/kedro-lab/text-sentiment-analysis-1/src/requirements.in
 terminado==0.13.2
     # via
     #   jupyter-server

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -144,17 +144,18 @@ def _convert_polarity_level_to_binary(label_column: pd.Series) -> pd.Series:
 def _count_labels(df: pd.DataFrame, columns_of_aspect_labels_per_person:list, labels: list, aspect_name:str) -> pd.DataFrame:
     df_t = df[columns_of_aspect_labels_per_person].T
     label_counts = pd.DataFrame(columns=labels)
+    
     for subject in df_t:
         c = df_t[subject].value_counts()
         label_counts = label_counts.append(dict(c), True)
     label_counts = label_counts.fillna(0)
     new_column_names = {}
+    
     for label in labels:
         new_column_names[label] = aspect_name + "_" + label
     label_counts.rename(columns=new_column_names, inplace=True)
-    for column in label_counts.columns:
-        df[column] = label_counts[column]
-    df = df.join(label_counts)
+    
+    df = df.join(label_counts, how='left')
     return df
 
 def _transform_aspect_label_columns_to_label_counts(df: pd.DataFrame) -> pd.DataFrame:
@@ -205,6 +206,7 @@ def extract_and_convert_xml_data(xml_content: str) -> pd.DataFrame:
     tree = _extract_xml_tree_from_text(xml_content)
     dataframe = _convert_testing_data_tree_to_dataframe(tree)
     return dataframe
+
 def preprocess_text_column(
         dataframe: pd.DataFrame,
         stopwords_custom: str,

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -80,6 +80,15 @@ def _convert_labelled_data_tree_to_dataframe(tree: ET.ElementTree) -> pd.DataFra
     dataframe = pd.DataFrame(rows, columns = columns)
     return dataframe
 
+def _fix_labels_typos(df: pd.DataFrame) -> pd.DataFrame:
+    df['price_0'] = df['price_0'].str.replace('positivetive', 'positive')
+    df['food_1'] = df['food_1'].str.replace('negtive', 'negative')
+    df['service_1'] = df['service_1'].str.replace('neative', 'negative')
+    df['ambience_1'] = df['ambience_1'].str.strip()
+    df['ambience_0'] = df['ambience_0'].str.replace('posituve', 'positive')
+    return df
+
+
 def _normalize_text(x: str) -> str:
     x = x.strip()
     x = x.lower()
@@ -196,7 +205,6 @@ def extract_and_convert_xml_data(xml_content: str) -> pd.DataFrame:
     tree = _extract_xml_tree_from_text(xml_content)
     dataframe = _convert_testing_data_tree_to_dataframe(tree)
     return dataframe
-
 def preprocess_text_column(
         dataframe: pd.DataFrame,
         stopwords_custom: str,
@@ -324,6 +332,7 @@ def create_labelled_data_table(
     """
     labelled_data["review_id"] = labelled_data["review_id"].astype(str)
     labelled_data["review_id"] = [str(uuid.uuid4()) for _ in range(len(labelled_data.index))]
+    labelled_data = _fix_labels_typos(labelled_data)
     labelled_data = _transform_aspect_label_columns_to_label_counts(labelled_data)
     return labelled_data
 

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -191,7 +191,7 @@ def _select_agreed_subjects_on_polarity_level(df: pd.DataFrame, aspect:str, thre
     agreed_polarity_level = df.loc[
         (df[aspect+'_unknown'] < aspect_mid_lower_bound) &
         (
-            (df[aspect+'_negative'] > mid_upper_bound) | (df[aspect+'_negative'] < mid_lower_bound)
+            (df[aspect+'_negative'] > polarity_mid_upper_bound) | (df[aspect+'_negative'] < polarity_mid_lower_bound)
         )
     ]
     return agreed_polarity_level[['review_id']]

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/nodes.py
@@ -137,12 +137,14 @@ def _count_labels(df: pd.DataFrame, columns_of_aspect_labels_per_person:list, la
     label_counts = pd.DataFrame(columns=labels)
     for subject in df_t:
         c = df_t[subject].value_counts()
-        new_df = new_df.append(dict(c), True)
+        label_counts = label_counts.append(dict(c), True)
     label_counts = label_counts.fillna(0)
     new_column_names = {}
     for label in labels:
         new_column_names[label] = aspect_name + "_" + label
-    label_counts = label_counts.rename(columns=new_column_names, inplace=True)
+    label_counts.rename(columns=new_column_names, inplace=True)
+    for column in label_counts.columns:
+        df[column] = label_counts[column]
     df = df.join(label_counts)
     return df
 
@@ -156,13 +158,13 @@ def _transform_aspect_label_columns_to_label_counts(df: pd.DataFrame) -> pd.Data
             aspect_labels_per_person.append(aspect+"_"+str(rater_id))
             # labelled_data[aspect+"_presence_"+str(rater_id)] = _convert_aspect_level_to_binary(labelled_data[aspect+"_"+str(rater_id)])
             # labelled_data[aspect+"_positive_"+str(rater_id)] = _convert_polarity_level_to_binary(labelled_data[aspect+"_"+str(rater_id)])
-        labelled_data = _count_labels(
-            df=labelled_data,
+        df = _count_labels(
+            df=df,
             columns_of_aspect_labels_per_person=aspect_labels_per_person,
             labels= labels,
             aspect_name=aspect
         )
-    return labelled_data
+    return df
 
 def extract_and_convert_labelled_data(xml_content: str) -> pd.DataFrame:
     """ Extract content of XML file of labelled data 

--- a/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
+++ b/text-sentiment-analysis-1/src/text_sentiment_analysis_1/pipelines/data_preprocessing/pipeline.py
@@ -5,14 +5,16 @@ generated using Kedro 0.17.7
 
 from kedro.pipeline import Pipeline, node, pipeline
 from .nodes import (
+    create_agreed_aspect_level_table,
+    create_agreed_polarity_level_table,
+    create_gold_standard_table, 
+    create_labelled_data_table,
+    create_unlabelled_data_table,
     extract_and_convert_labelled_data, 
     extract_and_convert_xml_data, 
-    preprocess_text_column, 
-    preprocess_gold_standard, 
-    create_gold_standard_table, 
-    create_unlabelled_data_table,
-    create_labelled_data_table,
     extract_train_test_features_from_texts, 
+    preprocess_gold_standard, 
+    preprocess_text_column, 
 )
 
 def create_pipeline(**kwargs) -> Pipeline:
@@ -81,7 +83,19 @@ def create_pipeline(**kwargs) -> Pipeline:
                 inputs="preprocessed_labelled_data",
                 outputs="labelled_data_table",
                 name="create_labelled_data_table_node",
-            )
+            ),
+            node(
+                func=create_agreed_aspect_level_table,
+                inputs="labelled_data_table",
+                outputs="agreed_aspect_table",
+                name="create_agreed_aspect_level_table_node",
+            ),
+            node(
+                func=create_agreed_polarity_level_table,
+                inputs="labelled_data_table",
+                outputs="agreed_polarity_table",
+                name="create_agreed_polarity_level_table_node",
+            ),
             # node(
             #     func=extract_train_test_features_from_texts,
             #     inputs=[
@@ -113,6 +127,8 @@ def create_pipeline(**kwargs) -> Pipeline:
             "typed_testing_data",
             "unlabelled_data_table",
             "gold_standard_table",
+            "agreed_aspect_table",
+            "agreed_polarity_table"
             # "converted_testing_data",
             # "feature_tf_train",
             # "feature_tf_idf_train",


### PR DESCRIPTION
## Changes:
- implement agreement measure (custom algorithm)
- installed `statsmodel` dependency
- created table containing review_ids of agreement on **aspect level** and **polarity level**

## Fixes:
- typo label renaming, includes:
```
'positivetive'  -> 'positive'
'negtive',       -> 'negative'
'neative',       ->  'negative'    
'posituve'      ->  'positive'   
```

## Notes:
- Agreement on **aspect level** means that more than 70% of annotators agreed that certain aspect is present or not present at all
- Agreement on **polarity level** means that more than (30%) of annotators agreed that the present aspect, is reviewed as negative xor positive
- Subjects that are not included by the two filters above are considered as **uncertain** or there is some **disagreement** between annotators